### PR TITLE
ps server支持按key设置dtype

### DIFF
--- a/internlm/param_server/common/config.py
+++ b/internlm/param_server/common/config.py
@@ -142,31 +142,31 @@ def get_param_shapes(config):
 
     # Define parameter shapes
     param_shapes = {
-        "attention_norm.weight": (hidden_size,),  # Layer 23 attention norm weight
-        "ffn_norm.weight": (hidden_size,),  # Layer 23 feedforward norm weight
-        "attention.wqkv.weight": (int(q_dim + 2 * kv_dim), hidden_size),  # Combined QKV weight for attention
-        "attention.wq.weight": (q_dim, hidden_size),  # Query weight for attention
-        "attention.wk.weight": (kv_dim, hidden_size),  # Key weight for attention
-        "attention.wv.weight": (kv_dim, hidden_size),  # Value weight for attention
-        "attention.wo.weight": (hidden_size, q_dim),  # Output projection weight for attention
-        "feed_forward.w1.weight": (int(mlp_hidden_features), hidden_size),  # MLP first layer weight
-        "feed_forward.w3.weight": (int(mlp_hidden_features), hidden_size),  # MLP third layer weight
-        "feed_forward.w2.weight": (hidden_size, int(mlp_hidden_features)),  # MLP second layer weight
-        "feed_forward.fused_w1_w3.weight": (int(mlp_hidden_features) * 2, hidden_size),  # Fused first and third layer weight
-        "norm.weight": (hidden_size,),  # Final normalization layer weight
-        "tok_embeddings.weight": (vocab_size, hidden_size),  # Token embedding matrix
-        "output.weight": (vocab_size, hidden_size),  # Output projection weight
-        "embed_tokens.weight": (vocab_size, hidden_size), # Token embedding matrix of qwen2
-        "attention.wq.bias": (q_dim,),
-        "attention.wk.bias": (kv_dim,),
-        "attention.wv.bias": (kv_dim,),
-        "attention.wo.bias": (q_dim,),
-        "attention.k_norm.weight": (attn_head_dim,),
-        "attention.q_norm.weight": (attn_head_dim,),
-        "feed_forward.moe_layer.gate.wg.weight": (attn_head_dim, hidden_size),
-        "w1.weight": (mlp_ratio * hidden_size, hidden_size),
-        "w2.weight": (hidden_size, mlp_ratio * hidden_size),
-        "w3.weight": (mlp_ratio * hidden_size, hidden_size),
+        "attention_norm.weight": {"shape": (hidden_size,), "dtype": torch.float32},  # Layer 23 attention norm weight
+        "ffn_norm.weight": {"shape": (hidden_size,), "dtype": torch.float32},  # Layer 23 feedforward norm weight
+        "attention.wqkv.weight": {"shape": (int(q_dim + 2 * kv_dim), hidden_size), "dtype": torch.bfloat16},  # Combined QKV weight for attention
+        "attention.wq.weight": {"shape": (q_dim, hidden_size), "dtype": torch.bfloat16},  # Query weight for attention
+        "attention.wk.weight": {"shape": (kv_dim, hidden_size), "dtype": torch.bfloat16},  # Key weight for attention
+        "attention.wv.weight": {"shape": (kv_dim, hidden_size), "dtype": torch.bfloat16},  # Value weight for attention
+        "attention.wo.weight": {"shape": (hidden_size, q_dim), "dtype": torch.bfloat16},  # Output projection weight for attention
+        "feed_forward.w1.weight": {"shape": (int(mlp_hidden_features), hidden_size), "dtype": torch.bfloat16},  # MLP first layer weight
+        "feed_forward.w3.weight": {"shape": (int(mlp_hidden_features), hidden_size), "dtype": torch.bfloat16},  # MLP third layer weight
+        "feed_forward.w2.weight": {"shape": (hidden_size, int(mlp_hidden_features)), "dtype": torch.bfloat16},  # MLP second layer weight
+        "feed_forward.fused_w1_w3.weight": {"shape": (int(mlp_hidden_features) * 2, hidden_size), "dtype": torch.bfloat16},  # Fused first and third layer weight
+        "norm.weight": {"shape": (hidden_size,), "dtype": torch.float32},  # Final normalization layer weight
+        "tok_embeddings.weight": {"shape": (vocab_size, hidden_size), "dtype": torch.bfloat16},  # Token embedding matrix
+        "output.weight": {"shape": (vocab_size, hidden_size), "dtype": torch.bfloat16},  # Output projection weight
+        "embed_tokens.weight": {"shape": (vocab_size, hidden_size), "dtype": torch.bfloat16}, # Token embedding matrix of qwen2
+        "attention.wq.bias": {"shape": (q_dim,), "dtype": torch.bfloat16},
+        "attention.wk.bias": {"shape": (kv_dim,), "dtype": torch.bfloat16},
+        "attention.wv.bias": {"shape": (kv_dim,), "dtype": torch.bfloat16},
+        "attention.wo.bias": {"shape": (q_dim,), "dtype": torch.bfloat16},
+        "attention.k_norm.weight": {"shape": (attn_head_dim,), "dtype": torch.bfloat16},
+        "attention.q_norm.weight": {"shape": (attn_head_dim,), "dtype": torch.bfloat16},
+        "feed_forward.moe_layer.gate.wg.weight": {"shape": (attn_head_dim, hidden_size), "dtype": torch.float32},
+        "w1.weight": {"shape": (mlp_ratio * hidden_size, hidden_size), "dtype": torch.bfloat16},
+        "w2.weight": {"shape": (hidden_size, mlp_ratio * hidden_size), "dtype": torch.bfloat16},
+        "w3.weight": {"shape": (mlp_ratio * hidden_size, hidden_size), "dtype": torch.bfloat16},
     }
 
     return param_shapes

--- a/internlm/param_server/common/initialize.py
+++ b/internlm/param_server/common/initialize.py
@@ -51,9 +51,15 @@ def check_state_dict(state_dict, param_shapes):
             param_key = key
         if "experts" in key:
             param_key = key[-9:]
+
+        expected_shape = param_shapes[param_key]["shape"]
+        expected_dtype = param_shapes[param_key]["dtype"]
+
         assert (
-            value.shape == param_shapes[param_key]
-        ), f"Shape mismatch for parameter {key}, expected {param_shapes[param_key]}, got {value.shape}"
+            value.shape == expected_shape
+        ), f"Shape mismatch for parameter {key}, expected {expected_shape}, got {value.shape}"
+        if value.dtype != expected_dtype:
+            state_dict[key] = value.to(expected_dtype)
 
 
 OPTIMIZER_MAP = {

--- a/internlm/param_server/common/utils.py
+++ b/internlm/param_server/common/utils.py
@@ -110,12 +110,13 @@ def serialize_layer(state_dict: Dict[str, torch.Tensor]) -> List[bytes]:
         state_dict(Dict[str, torch.Tensor]): layer weight
 
     Returns:
-        List[bytes]: data_size, key_num, chunk_lens_of_one_key, keys, shapes, chunks
+        List[bytes]: data_size, key_num, chunk_lens_of_one_key, keys, shapes, dtypes, chunks
     """
     start_ts = time.time()
     data_size = 0
     keys = []
     shapes = []
+    dtypes = []
     chunks = []
     chunk_lens = []
 
@@ -128,10 +129,17 @@ def serialize_layer(state_dict: Dict[str, torch.Tensor]) -> List[bytes]:
         chunks += serialized_parts
         keys.append(key.encode("utf-8"))
         shapes.append(list_to_str(value.shape).encode("utf-8"))
+        dtypes.append(str(value.dtype).encode("utf-8"))
         chunk_lens.append(len(serialized_parts))
 
     key_num = len(state_dict)
-    result = [str(data_size).encode("utf-8"), str(key_num).encode("utf-8"), list_to_str(chunk_lens).encode("utf-8")] + keys + shapes + chunks
+    result = (
+        [str(data_size).encode("utf-8"), str(key_num).encode("utf-8"), list_to_str(chunk_lens).encode("utf-8")]
+        + keys
+        + shapes
+        + dtypes
+        + chunks
+    )
     end_ts = time.time()
     logger.info(f"serialize_layer success, cost: {end_ts-start_ts:.3f}. length: {data_size}")
     return result
@@ -147,23 +155,28 @@ def deserialize_layer(group_id: int, layer_id: int, message_parts: List[bytes]) 
         data_size = int(message_parts[0].decode("utf-8"))
         key_num = int(message_parts[1].decode("utf-8"))
         chunk_lens = str_to_list(message_parts[2].decode("utf-8"))
-        chunk_num = 3 + 2*key_num + sum(chunk_lens)
+        chunk_num = 3 + 3 * key_num + sum(chunk_lens)
         if len(message_parts) != chunk_num:
             raise ValueError(f"invalid PUT request, expect {chunk_num=} parameters, but got {len(message_parts)=}")
-        keys = [key.decode("utf-8") for key in message_parts[3:3+key_num]]
-        shapes = [str_to_list(shape_str.decode("utf-8")) for shape_str in message_parts[3+key_num:3+key_num*2]]
+        keys = [key.decode("utf-8") for key in message_parts[3 : 3 + key_num]]
+        shapes = [str_to_list(shape_str.decode("utf-8")) for shape_str in message_parts[3 + key_num : 3 + key_num * 2]]
+        dtypes = [
+            torch_dtype_from_str(dtype_str.decode("utf-8"))
+            for dtype_str in message_parts[3 + key_num * 2 : 3 + key_num * 3]
+        ]
     except ValueError as e:
         logger.warning(f"Invalid PUT parameters from {group_id=} {layer_id=} {e}")
         return None
 
-    start_idx = 3 + key_num*2
+    start_idx = 3 + key_num * 3
     total_len = 0
     state_dict = {}
     for idx in range(key_num):
         key = keys[idx]
         shape = shapes[idx]
+        dtype = dtypes[idx]
         chunk_len = chunk_lens[idx]
-        tensor_data = b"".join(message_parts[start_idx : start_idx+chunk_len])
+        tensor_data = b"".join(message_parts[start_idx : start_idx + chunk_len])
         start_idx += chunk_len
         total_len += len(tensor_data)
         try:
@@ -178,13 +191,19 @@ def deserialize_layer(group_id: int, layer_id: int, message_parts: List[bytes]) 
     if data_size != total_len:
         logger.warning(
             f"Received incomplete state_dict from {group_id=} {layer_id=}, "
-            f"Expected {data_size} bytes, got {total_len} bytes.")
+            f"Expected {data_size} bytes, got {total_len} bytes."
+        )
         return None
 
     check_state_dict(state_dict, param_shapes)
     end_ts = time.time()
     logger.info(f"deserialize_layer success, cost: {end_ts-start_ts:.3f}. length: {data_size}")
     return state_dict
+
+def torch_dtype_from_str(dtype_str: str) -> torch.dtype:
+    if not dtype_str.startswith("torch."):
+        raise ValueError(f"Invalid dtype string: {dtype_str}")
+    return getattr(torch, dtype_str[6:])
 
 class BufferManager:
     """

--- a/internlm/param_server/ps/server.py
+++ b/internlm/param_server/ps/server.py
@@ -328,9 +328,13 @@ class ParameterServer:
     def get_layer_state_dict(self, layer_id: int) -> Dict[str, torch.Tensor]:
         layer_state_dict = {}
         for key, value in self.model_state_dict.items():
-            dtype = self.origin_dtype
-            if "feed_forward.moe_layer.gate.wg.weight" in key:
-                dtype = torch.float32
+            param_key = None
+            if key.startswith("layers."):
+                param_key = ".".join(key.split(".")[2:])
+            else:
+                param_key = key
+            dtype = config.param_shapes.get(param_key, {}).get("dtype", self.origin_dtype)
+
             if key.startswith("layers"):
                 layer_idx = int(key.split(".")[1])
                 if layer_idx == layer_id:


### PR DESCRIPTION
1. param_shapes 现在同时存储每层参数的 shape 和 dtype
2. 更新了序列化和反序列化逻辑，将 dtype 信息包含在客户端和参数服务器之间传输的数据流中； check_state_dict 函数现在会同时验证参数的 shape 和 dtype，自动将加载的张量转换为预期的 dtype